### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "centraldesktop/protobuf-php": "0.5.*"
     },
     "require-dev": {
-      "phpunit/phpunit": "3.7.*"
+      "phpunit/phpunit": "^4.8.36*"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/tests/GtfsRealtimeTest.php
+++ b/tests/GtfsRealtimeTest.php
@@ -16,8 +16,9 @@
  */
 
 use transit_realtime\FeedMessage;
+use PHPUnit\Framework\TestCase;
 
-class GtfsRealtimeTest extends PHPUnit_Framework_TestCase
+class GtfsRealtimeTest extends TestCase
 {
   public function testParse()
   {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just need to bump PHPUnit version to [4.8.36](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21) for compatibility.