### PR TITLE
Deprecate PHP bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For bindings in other languages, see the
 [gtfs-realtime-bindings](https://github.com/google/gtfs-realtime-bindings)
 project.
 
+**Deprecated:** *As of February 2019, the official `google-protobuf` Google protoc tool [doesn't support proto2 files](https://github.com/protocolbuffers/protobuf/issues/3623).  As a result we are deprecating the PHP bindings until official support for proto2 files is implemented in the Google protocol buffer tools.*
+
 ## Add the Dependency
 
 To use the `gtfs-realtime-bindings-php` classes in your own project, you need

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1,17 +1,29 @@
 # How-To Update Bindings When gtfs-realtime.proto Changes
 
-First, make sure you have all [Composer](https://getcomposer.org/) dependencies
-installed:
+## Regenerate the language binding source from gtfs-realtime.proto.
+
+## One-Time Setup
+
+1. Download and setup [php](http://www.php.net/).  As of February 2019 we're using 7.3.3.
+1. Download and install [Composer](https://getcomposer.org/)
+1. Make sure you have all [Composer](https://getcomposer.org/) dependencies
+installed by running:
 
 ```
 composer update
 ```
+
+**FIXME:** *As of February 2019, the official `google-protobuf` Google protoc tool [doesn't support proto2 files](https://github.com/protocolbuffers/protobuf/issues/3623).  As a result we are deprecating the PHP bindings until official support for proto2 files is implemented in the Google protocol buffer tools.*
+
+#### Every time `gtfs-realtime.proto` changes
 
 Regenerate the language binding source from gtfs-realtime.proto.
 
 ```
 vendor/bin/protoc-gen-php.php --include=../gtfs-realtime-bindings --out=src ../gtfs-realtime-bindings/gtfs-realtime.proto
 ```
+
+(or, on Windows, `vendor/bin/protoc-gen-php.php.bat --include=../gtfs-realtime-bindings --out=src ../gtfs-realtime-bindings/gtfs-realtime.proto`)
 
 Add the license header back to the generated source file.
 
@@ -22,6 +34,14 @@ Test the generated code:
 ```
 vendor/bin/phpunit
 ````
+
+## Publishing a new release
+
+#### One-Time Setup
+
+?
+
+#### Every release
 
 Tag the new release:
 


### PR DESCRIPTION
*Work-in-progress pull request - Please do not merge*

As of February 2019, the official `google-protobuf` Google protoc tool [doesn't support proto2 files](https://github.com/protocolbuffers/protobuf/issues/3623).  As a result we are deprecating the PHP bindings until official support for proto2 files is implemented in the Google protocol buffer tools.

I've opened an issue asking if anyone is using the PHP bindings at https://github.com/google/gtfs-realtime-bindings/issues/46.